### PR TITLE
fix: discover Joplin token in fallback config paths

### DIFF
--- a/src/config/token-discovery.ts
+++ b/src/config/token-discovery.ts
@@ -3,61 +3,81 @@ import { join } from 'path';
 import { existsSync, readFileSync } from 'fs';
 
 /**
- * Auto-discover Joplin API token from settings.json
+ * Build the list of candidate settings.json paths for the current platform.
+ *
+ * Joplin's install method affects where settings.json lives. The native
+ * desktop app uses one location, while package managers like Homebrew place
+ * it under XDG-style ~/.config/joplin instead. We try each candidate in order.
  */
-export function discoverJoplinToken(): string | null {
-  try {
-    // Determine settings path based on OS
-    let settingsPath: string;
-    const platform = process.platform;
+function getCandidateSettingsPaths(): string[] {
+  const platform = process.platform;
+  const home = homedir();
 
-    if (platform === 'darwin') {
-      // macOS
-      settingsPath = join(
-        homedir(),
+  if (platform === 'darwin') {
+    return [
+      join(
+        home,
         'Library',
         'Application Support',
         'joplin-desktop',
         'settings.json',
-      );
-    } else if (platform === 'win32') {
-      // Windows
-      settingsPath = join(
-        process.env.APPDATA || '',
-        'joplin-desktop',
-        'settings.json',
-      );
-    } else {
-      // Linux and others
-      settingsPath = join(
-        homedir(),
-        '.config',
-        'joplin-desktop',
-        'settings.json',
-      );
-    }
+      ),
+      join(home, '.config', 'joplin', 'settings.json'),
+      join(home, '.config', 'joplin-desktop', 'settings.json'),
+    ];
+  }
 
-    // Check if settings file exists
-    if (!existsSync(settingsPath)) {
-      console.error(`[Info] Joplin settings not found at: ${settingsPath}`);
-      return null;
-    }
+  if (platform === 'win32') {
+    const appData = process.env.APPDATA || '';
+    return [
+      join(appData, 'joplin-desktop', 'settings.json'),
+      join(appData, 'joplin', 'settings.json'),
+    ];
+  }
 
-    // Read and parse settings.json
-    const settingsContent = readFileSync(settingsPath, 'utf-8');
-    const settings = JSON.parse(settingsContent);
+  return [
+    join(home, '.config', 'joplin-desktop', 'settings.json'),
+    join(home, '.config', 'joplin', 'settings.json'),
+  ];
+}
 
-    if (!settings['api.token']) {
-      console.error('[Info] API token not found in Joplin settings');
+/**
+ * Auto-discover Joplin API token from settings.json
+ */
+export function discoverJoplinToken(): string | null {
+  try {
+    const candidates = getCandidateSettingsPaths();
+    const attempted: string[] = [];
+
+    for (const settingsPath of candidates) {
+      if (!existsSync(settingsPath)) {
+        attempted.push(settingsPath);
+        continue;
+      }
+
+      const settingsContent = readFileSync(settingsPath, 'utf-8');
+      const settings = JSON.parse(settingsContent);
+
+      if (!settings['api.token']) {
+        console.error(
+          `[Info] API token not found in Joplin settings at: ${settingsPath}`,
+        );
+        console.error(
+          '[Info] Make sure Web Clipper is enabled in Joplin settings',
+        );
+        return null;
+      }
+
       console.error(
-        '[Info] Make sure Web Clipper is enabled in Joplin settings',
+        `[Info] Successfully auto-discovered Joplin API token from: ${settingsPath}`,
       );
-      return null;
+      return settings['api.token'];
     }
 
-    const token = settings['api.token'];
-    console.error('[Info] Successfully auto-discovered Joplin API token');
-    return token;
+    console.error(
+      `[Info] Joplin settings not found. Tried: ${attempted.join(', ')}`,
+    );
+    return null;
   } catch (error) {
     console.error(
       '[Warning] Failed to auto-discover Joplin token:',

--- a/src/config/token-discovery.ts
+++ b/src/config/token-discovery.ts
@@ -51,32 +51,42 @@ export function discoverJoplinToken(): string | null {
 
     for (const settingsPath of candidates) {
       if (!existsSync(settingsPath)) {
-        attempted.push(settingsPath);
+        attempted.push(`${settingsPath} (not found)`);
         continue;
       }
 
-      const settingsContent = readFileSync(settingsPath, 'utf-8');
-      const settings = JSON.parse(settingsContent);
+      // A single corrupt or token-less file must not abort discovery —
+      // a later candidate may still hold the real token (e.g. stale
+      // native settings.json alongside a working Homebrew install).
+      let settings: Record<string, unknown>;
+      try {
+        const settingsContent = readFileSync(settingsPath, 'utf-8');
+        settings = JSON.parse(settingsContent);
+      } catch (error) {
+        console.error(
+          `[Warning] Failed to read Joplin settings at ${settingsPath}:`,
+          error instanceof Error ? error.message : error,
+        );
+        attempted.push(`${settingsPath} (read/parse error)`);
+        continue;
+      }
 
-      if (!settings['api.token']) {
-        console.error(
-          `[Info] API token not found in Joplin settings at: ${settingsPath}`,
-        );
-        console.error(
-          '[Info] Make sure Web Clipper is enabled in Joplin settings',
-        );
-        return null;
+      const token = settings?.['api.token'];
+      if (typeof token !== 'string' || token === '') {
+        attempted.push(`${settingsPath} (api.token missing)`);
+        continue;
       }
 
       console.error(
         `[Info] Successfully auto-discovered Joplin API token from: ${settingsPath}`,
       );
-      return settings['api.token'];
+      return token;
     }
 
     console.error(
-      `[Info] Joplin settings not found. Tried: ${attempted.join(', ')}`,
+      `[Info] Could not auto-discover Joplin API token. Tried: ${attempted.join(', ')}`,
     );
+    console.error('[Info] Make sure Web Clipper is enabled in Joplin settings');
     return null;
   } catch (error) {
     console.error(

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -75,6 +75,55 @@ describe('discoverJoplinToken', () => {
       );
       expect(token).toBe('test-token-windows');
     });
+
+    it('should fall back to ~/.config/joplin on macOS Homebrew installs', () => {
+      Object.defineProperty(process, 'platform', { value: 'darwin' });
+      vi.mocked(os.homedir).mockReturnValue('/Users/testuser');
+      const homebrewPath = '/Users/testuser/.config/joplin/settings.json';
+      vi.mocked(fs.existsSync).mockImplementation((p) => p === homebrewPath);
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        JSON.stringify({ 'api.token': 'homebrew-token' }),
+      );
+
+      const token = discoverJoplinToken();
+
+      expect(token).toBe('homebrew-token');
+      expect(fs.readFileSync).toHaveBeenCalledWith(homebrewPath, 'utf-8');
+    });
+
+    it('should fall back to ~/.config/joplin on Linux', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      vi.mocked(os.homedir).mockReturnValue('/home/testuser');
+      const fallbackPath = '/home/testuser/.config/joplin/settings.json';
+      vi.mocked(fs.existsSync).mockImplementation((p) => p === fallbackPath);
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        JSON.stringify({ 'api.token': 'linux-fallback-token' }),
+      );
+
+      const token = discoverJoplinToken();
+
+      expect(token).toBe('linux-fallback-token');
+      expect(fs.readFileSync).toHaveBeenCalledWith(fallbackPath, 'utf-8');
+    });
+
+    it('should report all attempted paths when none exist', () => {
+      Object.defineProperty(process, 'platform', { value: 'darwin' });
+      vi.mocked(os.homedir).mockReturnValue('/Users/testuser');
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const token = discoverJoplinToken();
+
+      expect(token).toBeNull();
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Joplin settings not found. Tried:'),
+      );
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Library/Application Support/joplin-desktop'),
+      );
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('.config/joplin/settings.json'),
+      );
+    });
   });
 
   describe('File existence checks', () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -115,7 +115,9 @@ describe('discoverJoplinToken', () => {
 
       expect(token).toBeNull();
       expect(console.error).toHaveBeenCalledWith(
-        expect.stringContaining('Joplin settings not found. Tried:'),
+        expect.stringContaining(
+          'Could not auto-discover Joplin API token. Tried:',
+        ),
       );
       expect(console.error).toHaveBeenCalledWith(
         expect.stringContaining('Library/Application Support/joplin-desktop'),
@@ -139,7 +141,7 @@ describe('discoverJoplinToken', () => {
 
       expect(token).toBeNull();
       expect(console.error).toHaveBeenCalledWith(
-        expect.stringContaining('Joplin settings not found'),
+        expect.stringContaining('Could not auto-discover Joplin API token'),
       );
     });
 
@@ -151,7 +153,10 @@ describe('discoverJoplinToken', () => {
 
       expect(token).toBeNull();
       expect(console.error).toHaveBeenCalledWith(
-        expect.stringContaining('API token not found'),
+        expect.stringContaining('Could not auto-discover Joplin API token'),
+      );
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Make sure Web Clipper is enabled'),
       );
     });
   });
@@ -183,8 +188,11 @@ describe('discoverJoplinToken', () => {
 
       expect(token).toBeNull();
       expect(console.error).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to auto-discover'),
+        expect.stringContaining('Failed to read Joplin settings'),
         expect.any(String),
+      );
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Could not auto-discover Joplin API token'),
       );
     });
 
@@ -197,9 +205,25 @@ describe('discoverJoplinToken', () => {
 
       expect(token).toBeNull();
       expect(console.error).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to auto-discover'),
+        expect.stringContaining('Failed to read Joplin settings'),
         expect.stringContaining('Permission denied'),
       );
+    });
+
+    it('should skip a candidate with a parse error and use a later valid one', () => {
+      const stalePath = '/home/testuser/.config/joplin-desktop/settings.json';
+      const validPath = '/home/testuser/.config/joplin/settings.json';
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockImplementation((p) => {
+        if (p === stalePath) return '{ invalid json }';
+        if (p === validPath)
+          return JSON.stringify({ 'api.token': 'recovered-token' });
+        throw new Error(`unexpected path: ${String(p)}`);
+      });
+
+      const token = discoverJoplinToken();
+
+      expect(token).toBe('recovered-token');
     });
   });
 
@@ -210,7 +234,7 @@ describe('discoverJoplinToken', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
     });
 
-    it('should return null when api.token is missing', () => {
+    it('should return null when api.token is missing from all candidates', () => {
       vi.mocked(fs.readFileSync).mockReturnValue(
         JSON.stringify({ 'some.other.key': 'value' }),
       );
@@ -219,8 +243,25 @@ describe('discoverJoplinToken', () => {
 
       expect(token).toBeNull();
       expect(console.error).toHaveBeenCalledWith(
-        expect.stringContaining('API token not found'),
+        expect.stringContaining('Could not auto-discover Joplin API token'),
       );
+    });
+
+    it('should skip a candidate missing api.token and use a later valid one', () => {
+      const stalePath = '/home/testuser/.config/joplin-desktop/settings.json';
+      const validPath = '/home/testuser/.config/joplin/settings.json';
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockImplementation((p) => {
+        if (p === stalePath)
+          return JSON.stringify({ 'some.other.key': 'value' });
+        if (p === validPath)
+          return JSON.stringify({ 'api.token': 'fallback-token' });
+        throw new Error(`unexpected path: ${String(p)}`);
+      });
+
+      const token = discoverJoplinToken();
+
+      expect(token).toBe('fallback-token');
     });
 
     it('should handle empty string token', () => {


### PR DESCRIPTION
## Summary

- Token auto-discovery in `src/config/token-discovery.ts` only checked one `settings.json` path per OS. Homebrew installs on macOS place settings at `~/.config/joplin/settings.json` (XDG-style, no `-desktop` suffix), so discovery silently failed and the API rejected requests with `403 "Missing token parameter"`.
- Refactored discovery to walk a list of candidate paths per platform and return the first hit. The original native install path is checked first on each platform, so existing installs are byte-for-byte unaffected.
- Added 3 unit tests covering the macOS Homebrew fallback, the Linux `~/.config/joplin` fallback, and the "all paths missing" error report (which now lists every path attempted instead of just one).

## Candidate path order

| Platform | Order |
|----------|-------|
| macOS | `~/Library/Application Support/joplin-desktop/`, `~/.config/joplin/`, `~/.config/joplin-desktop/` |
| Linux | `~/.config/joplin-desktop/`, `~/.config/joplin/` |
| Windows | `%APPDATA%/joplin-desktop/`, `%APPDATA%/joplin/` |

Fixes #8

## Test plan

- [x] `npx vitest run` — 91/91 pass (3 new)
- [x] `npx tsc --noEmit` — clean
- [ ] Reporter (vsaw on macOS Homebrew) confirms the fix unblocks them