### PR TITLE
chore: bump @anthropic-ai/sandbox-runtime to 0.0.49 (#9)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/sandbox-runtime": "0.0.39",
+        "@anthropic-ai/sandbox-runtime": "0.0.49",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "form-data": "^4.0.4",
         "smol-toml": "^1.5.2",
@@ -38,15 +38,13 @@
       }
     },
     "node_modules/@anthropic-ai/sandbox-runtime": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sandbox-runtime/-/sandbox-runtime-0.0.39.tgz",
-      "integrity": "sha512-5hyO2nTCQHx3z8FM6XfJHlU5c6IlsrVcdK/3fRX9vUHQrvgJ1UHnR1/PeXOWKRZJ4WiothQTgfK2gafBqKjWJA==",
+      "version": "0.0.49",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sandbox-runtime/-/sandbox-runtime-0.0.49.tgz",
+      "integrity": "sha512-t8Ggc0A7UizxMGPk/ANEH8nwnCqzNWIKpkdKgxDVUaKNMQnMzzWR6aErrqIdU03/ZP5RN6/OL/kjFOw/Vox3KQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@pondwader/socks5-server": "^1.0.10",
-        "@types/lodash-es": "^4.17.12",
         "commander": "^12.1.0",
-        "lodash-es": "^4.17.23",
         "shell-quote": "^1.8.3",
         "zod": "^3.24.1"
       },
@@ -896,21 +894,6 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.17.24",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
-      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
-      "license": "MIT"
-    },
-    "node_modules/@types/lodash-es": {
-      "version": "4.17.12",
-      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
-      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
     },
     "node_modules/@types/node": {
       "version": "22.19.17",
@@ -4326,12 +4309,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
-      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "url": "https://github.com/belsar-ai/joplin-mcp/issues"
   },
   "dependencies": {
-    "@anthropic-ai/sandbox-runtime": "0.0.39",
+    "@anthropic-ai/sandbox-runtime": "0.0.49",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "form-data": "^4.0.4",
     "smol-toml": "^1.5.2",


### PR DESCRIPTION
## Summary

Closes #9. Bumps the pinned runtime dep `@anthropic-ai/sandbox-runtime` from `0.0.39` → `0.0.49` per the procedure in `RELEASE.md`. No source changes; two-file diff (`package.json` + `package-lock.json`).

## Upstream change triage (0.0.39 → 0.0.49)

Reviewed via `gh api repos/anthropic-experimental/sandbox-runtime/compare/v0.0.39...v0.0.49`.

**Net-positive security changes:**
- Isolate seccomp workload in nested PID ns and block `io_uring` — closes a known sandbox-escape vector.
- Sandbox hardening: TMPDIR write scope and seccomp arg comparison.
- Bake BPF filter into apply-seccomp, build in CI (removes runtime codegen of the seccomp filter).
- **Don't let `denyWrite` unmask a `denyRead /dev/null` bind; file-deny survives dir-allow** — regression fix we actually exercise: our `SANDBOX_CONFIG.denyWrite` at `src/sandbox/broker.ts:64-75` lists `/dev/null`.
- Fix `enableWeakerNestedSandbox` after apply-seccomp namespace changes.
- **Remove `lodash-es` dependency** — shrinks transitive attack surface. Lockfile drops `lodash-es`, `@types/lodash-es`, `@types/lodash`.
- Bump to 0.0.48 and fix npm audit vulnerabilities.

**Additive / inert for our config:**
- `allowRead` config option (we don't set it), upstream/parent HTTP proxy support (opt-in), `allowMachLookup` (macOS-only, we don't set it), seccomp `argv0` mode (not used), `RipgrepConfig.argv0` (not used), `GIT_SSH_COMMAND` DNS fix (we don't run git/SSH in-sandbox).

**Behavioral changes verified via tests:**
- `allow stat on all directories` — loosens stat; metadata, not contents. Integration test asserts `readdirSync('~/.ssh')` is blocked, which is a read, not a stat.
- `allow filesystem root traversal when denyRead includes '/'` — our `denyRead` doesn't include `/`; inert.
- `Sort denyRead paths shallow-first` — precedence refinement; our `denyRead` has no overlapping entries.

**API surface we depend on (`broker.ts`):** `initialize`, `checkDependencies`, `wrapWithSandbox`, `cleanupAfterCommand`, `reset` — all signatures unchanged. `SandboxConfig` gains optional fields only; non-breaking.

## Test plan

Run locally (Linux host with `bwrap` installed, so the integration block actually runs — not skipped):

- [x] `npm install` — clean resolve, 3 transitive packages removed (lodash-es chain)
- [x] `npm run typecheck`
- [x] `npm run lint:ci`
- [x] `npm run build`
- [x] `npm test` — **93/93 passing**, including all 8 sandbox integration tests:
  - vm-layer blocks on `import` / `process` / `require`
  - OS-sandbox blocks on outbound network, write to `/tmp/sandbox-test-escape`, read of `~/.ssh`, write to `/tmp/claude`
  - RPC allowlist passthrough
  - `broker.ts:147-154` fail-closed assertion (RELEASE.md's "sandbox smoke check")
- [ ] CI matrix (22.x / 24.x with `bubblewrap` installed) — confirm integration tests also green in GHA